### PR TITLE
Support Steal 1.0

### DIFF
--- a/default/index.js
+++ b/default/index.js
@@ -33,19 +33,25 @@ module.exports = generator.Base.extend({
     this.conflicter.force = true;
 
     // update package.json
-    this.fs.extendJSON(this.pkgPath, {
+    var pkg = require(this.pkgPath);
+    var stealProp = pkg.system ? "system" : "steal";
+
+    var newPkgConfig = {
       scripts: {
         deploy: "firebase deploy",
         "deploy:ci": "firebase deploy --token \"$FIREBASE_TOKEN\""
-      },
-      system: {
-        envs: {
-          'server-production': {
-            renderingBaseURL: 'https://' + firebaseAppName + '.firebaseapp.com/'
-          }
+      }
+    };
+
+    newPkgConfig[stealProp] = {
+      envs: {
+        'server-production': {
+          renderingBaseURL: 'https://' + firebaseAppName + '.firebaseapp.com/'
         }
       }
-    });
+    };
+
+    this.fs.extendJSON(this.pkgPath, newPkgConfig);
 
     this.fs.extendJSON(this.firebaseJsonPath, {
       hosting: {

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,7 @@ describe('donejs-firebase', function() {
       }
     });
     assert.JSONFileContent('package.json', {
-      system: {
+      steal: {
         envs: {
           'server-production': {
             renderingBaseURL: 'https://firebase-app-name.firebaseapp.com/'
@@ -43,7 +43,7 @@ describe('donejs-firebase', function() {
     assert.file(['package.json']);
     assert.JSONFileContent('package.json', {
       name: 'donejs-app',
-      system: {
+      steal: {
         main: 'donejs-app/index.stache!done-autorender',
         directories: {
           lib: 'src'

--- a/test/templates/package.json
+++ b/test/templates/package.json
@@ -20,7 +20,7 @@
     "src"
   ],
   "keywords": [],
-  "system": {
+  "steal": {
     "main": "donejs-app/index.stache!done-autorender",
     "directories": {
       "lib": "src"


### PR DESCRIPTION
This makes donejs-firebase support Steal 1.0 by setting the "steal"
property in package.json when available. Still backwards compatible with
Steal 0.16.